### PR TITLE
feat(proxy-config): throw error is serverUrl is undefined

### DIFF
--- a/proxy.conf.js
+++ b/proxy.conf.js
@@ -5,9 +5,13 @@ const vantageLoginProxyConfig = require('@td-vantage/ui-platform/auth/config/van
 /* Vantage and local development environments */
 /* * * * * * * * * * * */
 
-const serverUrl = 'https://vantage.url.io'; // REPLACE WITH VANTAGE BASE URL
-const localUrl = "localhost:4200";
-const localProto = "http"; // http or https
+const serverUrl = undefined; // Replace with Vantage base url. Ex: https://vantage.url.io
+const localUrl = 'localhost:4200';
+const localProto = 'http'; // http or https
+
+if (!serverUrl) {
+  throw Error('Update the serverUrl variable in the proxy.conf.js to point to your vantage env.');
+}
 
 /* * * * * * * * * * * */
 /* This section contains the routes proxied through */


### PR DESCRIPTION
Throw error is serverUrl is undefined in proxy config. Avoids runnning the server and being super lost why everything is broken. 

<img width="862" alt="Screen Shot 2019-08-22 at 11 32 39 AM" src="https://user-images.githubusercontent.com/7193975/63540221-909d9980-c4d0-11e9-82ac-178e8c4c4f20.png">

Test steps:
- [x] run `npm run serve`
- [x] Ensure command errors out